### PR TITLE
Make the base path of service configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,7 +7,8 @@ import (
 	"os"
 	"strconv"
 	"time"
-    "strings"
+	"strings"
+	"path/filepath"
 )
 
 var currentAgentStatus string = ""
@@ -78,7 +79,7 @@ func (t *ticker) resetTicker() {
 }
 
 func readConfig() {
-	xmlFile, err := os.Open("C:/ProgramData/LoadBalancer.org/LoadBalancer/config.xml")
+	xmlFile, err := os.Open(filepath.Join(basePath, "config.xml"))
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +96,7 @@ func readConfig() {
 }
 
 func InitConfig() {
-	f, err := os.OpenFile("C:/ProgramData/LoadBalancer.org/LoadBalancer/lbfbalogfile", os.O_RDWR | os.O_CREATE | os.O_APPEND, 0666)
+	f, err := os.OpenFile(filepath.Join(basePath, "lbfbalogfile"), os.O_RDWR | os.O_CREATE | os.O_APPEND, 0666)
 	if err != nil {
 	    log.Fatalf("error opening file: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,15 @@ package main
 import (
 	"github.com/kardianos/service"
 	"log"
+	"os"
+	"flag"
+	"path/filepath"
 )
 
-var logger service.Logger
+var (
+	logger service.Logger
+	basePath = flag.String("basepath", filepath.Join(os.Getenv("ProgramData"), "LoadBalancer.org", "LoadBalancer"), "Base path for service data")
+)
 
 type program struct{}
 

--- a/server.go
+++ b/server.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 	"net"
-    "strconv"
+	"strconv"
 )
 
 type Server struct {


### PR DESCRIPTION
This PR adds a command line flag to allow the "base path" to be overidden.

The default matches the current hard-coded value of: `C:\ProgramData\LoadBalancer.org\LoadBalancer\`

Example

```sh
go-feedback-agent -basepath "C:\Tools\HAProxy-Agent\"
```

